### PR TITLE
Update index.js quantifier

### DIFF
--- a/problems/quantifier/index.js
+++ b/problems/quantifier/index.js
@@ -12,6 +12,7 @@ exports.verify = verify({ modeReset: true }, function (args, t) {
   t.ok(f('123.jpeg'), '123.jpeg')
   t.notOk(f('abc.jpeg'), 'abc.jpeg')
   t.notOk(f('123abc.jpeg'), '123abc.jpeg')
+  t.notOk(f('abc123.jpeg'), 'abc123.jpeg')
   t.notOk(f('123'), '123')
   t.notOk(f('123.jpg2000'), '123.jpg2000')
   t.notOk(f('123.png'), '123.png')


### PR DESCRIPTION
Added a test to distinguish between /\d+.jpe?g$/.test(str) and /^\d+.jpe?g$/.test(str). Right now the former passes when it shouldn't.
